### PR TITLE
continuous integration testing via GitHub actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+      - name: install dependencies
+        run: pip install -r setup/nnt_requirements.txt
+      - name: unit tests
+        run: python -m test.complete_test_suite

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,11 +9,16 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [ '3.6', '3.7' ]
+    name: unit tests (python ${{ matrix.python-version }})
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: ${{ matrix.python-version }}
       - name: install dependencies
         run: pip install -r setup/nnt_requirements.txt
       - name: unit tests


### PR DESCRIPTION
Hi!

I added a rudimentary CI pipeline running on the new (and free 🚀) GitHub Actions.

It basically checks out the code, setups Python, installs the dependencies (via `pip` and `nnt_requirements.txt` file) and runs all unit tests for any newly submitted Pull Request and commit/push to master.

This is done for Python 3.6 & 3.7 as those seem to be the currently supported versions.

I also tried with newer versions of Python (3.8 and 3.9) though the requirements/pip install threw quite a few errors.

> I'd actually recommend building up a new environment by manually selecting the actually relevant packages (tensorflow, jupyter and maybe a few more) and trying to build a "minimal" requirements file from there. But that's a different topic:) 

You can check out the [last run on my fork of your repo](https://github.com/diveflo/Neural-Network-Translator/actions/runs/372880602).

Let me know what u think:)

